### PR TITLE
Update the version of bundler locked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,4 +347,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.4.5
+   2.6.3


### PR DESCRIPTION
We want this for better support for default_gems
