### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -5,6 +5,8 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/bagedevimo/pc4g/security/code-scanning/1](https://github.com/bagedevimo/pc4g/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal required permissions. Based on the workflow's steps, the `contents: read` permission is sufficient for most jobs, as they primarily involve checking out code, installing dependencies, and running tests or linters. For the `deploy` job, additional permissions may be required if it interacts with external services or APIs, but this is not evident from the provided code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
